### PR TITLE
Remove CentOS5, Upgrade Fedora 24=>25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ services:
 script:
 - >
   wget -O- bit.ly/ansibletest |
-  env DOCKER_IMAGES="centos:5 centos:7 debian:7 debian:8 fedora:20
-  fedora:24 ubuntu:14.04 ubuntu:16.04"
+  env DOCKER_IMAGES="centos:6 centos:7 debian:7 debian:8 fedora:20
+  fedora:25 ubuntu:14.04 ubuntu:16.04"
   ANSIBLE_VERSIONS="1.4.4 1.6.1 1.8.4 2.1.0.0" sh -x
 after_failure:
 - cat role-tester-ansible-master/.kitchen.yml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -61,8 +61,8 @@ galaxy_info:
     - 21
     - 22
     - 23
-  #  - 24
-  #  - 25
+    - 24
+    - 25
   #- name: opensuse
   #  versions:
   #  - all


### PR DESCRIPTION
per https://bugzilla.redhat.com/show_bug.cgi?id=1440366
and due to CentOS5 being end-of-lifed